### PR TITLE
Updated the Ring discovery code to parse out host names properly

### DIFF
--- a/src/ar/com/threelegs/newrelic/cassandra/util/CassandraHelper.java
+++ b/src/ar/com/threelegs/newrelic/cassandra/util/CassandraHelper.java
@@ -26,7 +26,8 @@ public class CassandraHelper {
 
 				if (m != null) {
 					for (Object key : m.keySet()) {
-						ret.add(key.toString().replaceFirst("/", ""));
+                        String val = key.toString();
+                        ret.add(val.substring(0, val.indexOf("/")));
 					}
 				}
 


### PR DESCRIPTION
We are using Cassandra 1.2.11, and the ring describe code was not parsing host names properly.  The key.toString() was returning the {hostname}/{ip address}, and then the "/" was being stripped out, leaving you with a hostname containing the hostname and ip address as one string.  This change parses out just the hostname part.  When running, we were always encountering an UnknownHostException.
