### PR TITLE
Remove range slice data from read latency metric calculation

### DIFF
--- a/src/ar/com/threelegs/newrelic/CassandraRing.java
+++ b/src/ar/com/threelegs/newrelic/CassandraRing.java
@@ -56,12 +56,6 @@ public class CassandraRing extends Agent {
 							ArrayList<Metric> metrics = new ArrayList<Metric>();
 
 							// Latency
-							Double rsl = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
-									"RangeSlice", "OneMinuteRate");
-							TimeUnit rslUnit = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
-									"RangeSlice", "LatencyUnit");
-							rsl = toMillis(rsl, rslUnit);
-
 							Double rl = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
 									"Read", "OneMinuteRate");
 							TimeUnit rlUnit = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
@@ -74,10 +68,8 @@ public class CassandraRing extends Agent {
 									"Write", "LatencyUnit");
 							wl = toMillis(wl, wlUnit);
 
-							metrics.add(new Metric("Cassandra/hosts/" + host + "/Latency/Reads", "millis", rsl));
 							metrics.add(new Metric("Cassandra/hosts/" + host + "/Latency/Reads", "millis", rl));
 							metrics.add(new Metric("Cassandra/hosts/" + host + "/Latency/Writes", "millis", wl));
-							metrics.add(new Metric("Cassandra/global/Latency/Reads", "millis", rsl));
 							metrics.add(new Metric("Cassandra/global/Latency/Reads", "millis", rl));
 							metrics.add(new Metric("Cassandra/global/Latency/Writes", "millis", wl));
 


### PR DESCRIPTION
This was causing read latency graphs to not match up with Opscenter.
Range slice should have separate metric data instead.

Typical read metric data from an idle cluster pre-patch:
[3.9878362E-4,2,0.0,3.9878362E-4,1.5902837E-7]

Typical read metric data from an idle cluster post-patch:
[6.023493E-4,1,6.023493E-4,6.023493E-4,3.6282466E-7]

The count of 2 was causing the average and minimum values to be off.

https://docs.newrelic.com/docs/plugin-developer-resources/metric-data-for-the-plugin-api#timeslice
"Count of the number of events this value represents over the time
period; the average is calculated by dividing total by count"
