### PR TITLE
Switch from OneMinuteRate to Mean for latency metrics

### DIFF
--- a/src/ar/com/threelegs/newrelic/CassandraRing.java
+++ b/src/ar/com/threelegs/newrelic/CassandraRing.java
@@ -63,13 +63,13 @@ public class CassandraRing extends Agent {
 							rsl = toMillis(rsl, rslUnit);
 
 							Double rl = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
-									"Read", "OneMinuteRate");
+									"Read", "Mean");
 							TimeUnit rlUnit = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
 									"Read", "LatencyUnit");
 							rl = toMillis(rl, rlUnit);
 
 							Double wl = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
-									"Write", "OneMinuteRate");
+									"Write", "Mean");
 							TimeUnit wlUnit = JMXHelper.queryAndGetAttribute(connection, "org.apache.cassandra.metrics", "Latency", "ClientRequest",
 									"Write", "LatencyUnit");
 							wl = toMillis(wl, wlUnit);


### PR DESCRIPTION
OneMinuteRate counts the number of requests per second over the last one
minute, while Mean measures the average latency over the last minute, which
comes much closer to the values graphed by Opscenter.

https://groups.google.com/forum/#!msg/nosql-databases/a6P12QVbd8o/wulNbttk-A0J
https://github.com/dropwizard/metrics/blob/master/metrics-core/src/main/java/com/codahale/metrics/Metered.java#L45
https://github.com/dropwizard/metrics/blob/master/metrics-core/src/main/java/com/codahale/metrics/Snapshot.java#L170

It's generally preferable to use the median (50thPercentile) instead of
the mean, but those values don't match well with Opscenter, based on my
testing. Being closed-source, it's hard to tell how exactly Opscenter
determines its metrics.
