### PR TITLE
Include plugin path for process detection

### DIFF
--- a/resources/varnish-new-relic.init-file
+++ b/resources/varnish-new-relic.init-file
@@ -33,7 +33,7 @@ do_start() {
 # Stop the application
 #
 do_stop() {
-        PID=`ps aux | grep $FILE_NAME | cut -d' ' -f2`
+        PID=`ps aux | grep $PLUGIN_PATH/$FILE_NAME | cut -d' ' -f2`
         kill -9 $PID
 }
 
@@ -43,7 +43,7 @@ do_stop() {
 #
 do_check()
 {
-    lines=`ps aux | grep $FILE_NAME | wc -l`
+    lines=`ps aux | grep $PLUGIN_PATH/$FILE_NAME | wc -l`
     if [ $lines -eq 2 ]
     then
         return 0


### PR DESCRIPTION
Other New Relic plugins are named [`plugin.jar'](https://github.com/newrelic-platform/newrelic_mysql_java_plugin). 

To avoid conflicts I suggest that we include the full path when identifying our own processes.

For a proper solution to this then I imagine a pidfile is the way to go but that is beyond my sysadm skills.