### PR TITLE
Fix process id identification

### DIFF
--- a/resources/varnish-new-relic.init-file
+++ b/resources/varnish-new-relic.init-file
@@ -33,7 +33,7 @@ do_start() {
 # Stop the application
 #
 do_stop() {
-        PID=`ps aux | grep $FILE_NAME | cut -d' ' -f2`
+        PID=`ps afx | grep $FILE_NAME | grep -v grep | awk '{print $1}'`
         kill -9 $PID
 }
 


### PR DESCRIPTION
I have had some troubles getting the init script to identify the pid properly on a Debian 7 box.

The problems seem to be related to the structure of the ps output and the cut command which always yields an empty response. I ended up using [an approach suggested on StackOverflow](http://stackoverflow.com/a/17440640).

I am not a Linux expert but it worked for me and perhaps it can be an inspiration for others or spark a discussion about the right way to go about this.